### PR TITLE
Fix colors path in SideNavLink component

### DIFF
--- a/src/Nav/SideNav/components/SideNavLink/index.scss
+++ b/src/Nav/SideNav/components/SideNavLink/index.scss
@@ -1,4 +1,4 @@
-@import '../../style/colors';
+@import '../../../../style/colors';
 
 .navbar-nav {
   opacity: 0.6;


### PR DESCRIPTION
Fixing broken path to `colors.scss` after SideNavLink component file structure was changed.