### PR TITLE
UI-27 Add active row state and support column specific sort

### DIFF
--- a/src/Grid/index.scss
+++ b/src/Grid/index.scss
@@ -26,7 +26,7 @@ $breakpoint-large: 60em; // 960px
   display: flex;
 }
 
-.co-row [class^="co-col"] {
+.co-row [class*="co-col"] {
   float: left;
   margin: 0.5rem 2%;
   min-height: 0.125rem;

--- a/src/SmartList/SmartList.spec.tsx
+++ b/src/SmartList/SmartList.spec.tsx
@@ -7,7 +7,6 @@ import { SmartList, IHeaderItem, IRowElement } from './'
 const cols: IHeaderItem[] = [
   {
     name: 'name',
-    sortable: true,
     displayName: 'name'
   },
 ]
@@ -67,12 +66,19 @@ describe('SmartList', () => {
         setContent(updated)
       }
 
+      const cols: IHeaderItem[] = [
+        {
+          name: 'name',
+          displayName: 'name',
+          handleSort
+        },
+      ]
+
 
       return (
         <SmartList
           data={content}
           cols={cols}
-          onSort={handleSort}
         />
       )
     } 

--- a/src/SmartList/SmartList.stories.tsx
+++ b/src/SmartList/SmartList.stories.tsx
@@ -104,11 +104,9 @@ const content: IRowElement[] = [
 const cols: IHeaderItem[] = [
   {
     name: 'ID',
-    handleSort: () => {/***/}
   },
   {
     name: 'Email',
-    handleSort: () => {/***/}
   },
   {
     name: 'Actions',
@@ -118,13 +116,9 @@ const cols: IHeaderItem[] = [
 const colsBlankActions: IHeaderItem[] = [
   {
     name: 'ID',
-    handleSort: () => {/***/},
-    sortable: true
   },
   {
     name: 'Email',
-    handleSort: () => {/***/},
-    sortable: true
   },
   {
     name: 'Actions',
@@ -141,6 +135,7 @@ stories.add(
         return acc
       }, {})
     )
+    const [activeRow, setActiveRow] = useState('')
 
     const [sortColIndex, setSortColIndex] = useState(0)
     const [sortColAscending, setSortColAscending] = useState(true)
@@ -163,9 +158,20 @@ stories.add(
       })
     }
 
-    const updateSelected = (selectedRows: ISelectedRows): void => {
-      setSelected(selectedRows)
-    }
+    const colsSortable: IHeaderItem[] = [
+      {
+        name: 'ID',
+        handleSort,
+      },
+      {
+        name: 'Email',
+        handleSort,
+      },
+      {
+        name: 'Actions',
+        displayName: ''
+      }
+    ]
 
     return (
       <div className='m-5'>
@@ -228,13 +234,14 @@ stories.add(
         <br />
         <br />
 
-        <h3>Selectable list items, sortable columns, nameless column for Actions</h3>
+        <h3>Selectable list items, click to choose active row, sortable columns, nameless column for Actions</h3>
         <SmartList
-          cols={colsBlankActions}
+          cols={colsSortable}
           data={sortedContent(content)}
           selectedRows={selected}
-          onRowSelect={updateSelected}
-          onSort={handleSort}
+          onRowSelect={setSelected}
+          activeRow={activeRow}
+          onActivate={setActiveRow}
         />
       </div>
     )

--- a/src/SmartList/SmartList.stories.tsx
+++ b/src/SmartList/SmartList.stories.tsx
@@ -48,7 +48,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: actions
+        element: <div></div>
       }
     ]
   },
@@ -68,7 +68,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: actions,
+        element: <div></div>,
       }
     ]
   },
@@ -95,7 +95,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: actions,
+        element: <div></div>,
       }
     ]
   }
@@ -169,7 +169,8 @@ stories.add(
       },
       {
         name: 'Actions',
-        displayName: ''
+        displayName: '',
+        width: 1
       }
     ]
 

--- a/src/SmartList/SmartList.stories.tsx
+++ b/src/SmartList/SmartList.stories.tsx
@@ -48,7 +48,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: <div></div>
+        element: actions
       }
     ]
   },
@@ -68,7 +68,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: <div></div>,
+        element: actions,
       }
     ]
   },
@@ -95,7 +95,7 @@ const content: IRowElement[] = [
       },
       {
         name: 'actions',
-        element: <div></div>,
+        element: actions,
       }
     ]
   }
@@ -169,8 +169,7 @@ stories.add(
       },
       {
         name: 'Actions',
-        displayName: '',
-        width: 1
+        displayName: ''
       }
     ]
 

--- a/src/SmartList/SmartList.tsx
+++ b/src/SmartList/SmartList.tsx
@@ -11,7 +11,8 @@ export interface IProps {
   cols: IHeaderItem[]
   selectedRows?: ISelectedRows
   onRowSelect?: (selected: ISelectedRows) => void
-  onSort?: (colIndex: number, ascending: boolean) => void
+  activeRow?: string
+  onActivate?: (id: string) => void
   textIfEmpty?: string
   header?: boolean
   loading?: boolean
@@ -22,7 +23,8 @@ const SmartList: React.FC<IProps> = ({
   cols,
   selectedRows,
   onRowSelect,
-  onSort,
+  activeRow,
+  onActivate,
   textIfEmpty,
   loading,
   header = true 
@@ -60,8 +62,8 @@ const SmartList: React.FC<IProps> = ({
       row.onClick(event)
     }
 
-    if (selectedRows) {
-      handleSelect(row.id, !selectedRows[row.id])
+    if (onActivate) {
+      onActivate(row.id.toString())
     }
   }
 
@@ -69,7 +71,6 @@ const SmartList: React.FC<IProps> = ({
     <Header
       selectAllCol={!!selectedRows}
       onSelectAll={handleSelectAll}
-      onSort={onSort}
       cols={cols}
     />
   )
@@ -83,6 +84,7 @@ const SmartList: React.FC<IProps> = ({
         columns={row.columns}
         disabled={row.disabled}
         className={row.className}
+        isActive={row.id.toString() === activeRow}
         selectable={!!selectedRows}
         selected={selectedRows && selectedRows[row.id]}
         onSelect={handleSelect}

--- a/src/SmartList/SmartList.tsx
+++ b/src/SmartList/SmartList.tsx
@@ -81,6 +81,7 @@ const SmartList: React.FC<IProps> = ({
         onClick={(e) => handleClick(row, e)}
         key={row.id}
         rowId={row.id}
+        cols={cols}
         columns={row.columns}
         disabled={row.disabled}
         className={row.className}

--- a/src/SmartList/components/Header/Header.tsx
+++ b/src/SmartList/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import { IHeaderItem } from '../../../types'
 import { NAVY } from '../../../style/colors'
 import './index.scss'
 
-const Header: React.FC<IProps> = ({ cols, selectAllCol, onSort, onSelectAll }) => {
+const Header: React.FC<IProps> = ({ cols, selectAllCol, onSelectAll }) => {
   const [allChecked, toggleAllChecked] = useState(false)
   const [sortColumn, setSortColumn] = useState<string>(cols[0].name)
   const [sortAscending, setSortAscending] = useState(true)
@@ -24,17 +24,17 @@ const Header: React.FC<IProps> = ({ cols, selectAllCol, onSort, onSelectAll }) =
     return item.name
   }
 
-  const handleSortButtonClicked = (colIndex: number): void => {
-    if (onSort) {
+  const handleSortButtonClicked = (col: IHeaderItem, colIndex: number): void => {
+    if (col.handleSort) {
       const item = cols[colIndex]
 
       if (sortColumn === item.name) {
-        onSort(colIndex, !sortAscending)
+        col.handleSort(colIndex, !sortAscending)
         setSortAscending(!sortAscending)
         return
       }
 
-      onSort(colIndex, true)
+      col.handleSort(colIndex, true)
       setSortAscending(true)
       setSortColumn(item.name)
     }
@@ -87,7 +87,7 @@ const Header: React.FC<IProps> = ({ cols, selectAllCol, onSort, onSelectAll }) =
   }
 
   const sortable = (x: IHeaderItem): boolean => {
-    return !!onSort && !(x.displayName && x.displayName === '') && !!x.sortable
+    return !!x.handleSort && !(x.displayName && x.displayName === '')
   }
 
   return (
@@ -110,8 +110,8 @@ const Header: React.FC<IProps> = ({ cols, selectAllCol, onSort, onSelectAll }) =
         <Col 
           data-testid={`header-column-${x.name}`}
           key={x.name}
-          onClick={() => sortable(x) && handleSortButtonClicked(idx)}
-          className={onSort ? 'cursor-pointer' : ''}
+          onClick={() => sortable(x) && handleSortButtonClicked(x, idx)}
+          className={sortable(x) ? 'cursor-pointer' : ''}
         >
           {nameDisplay(x)}
           {sortable(x) && sortButton(x)}

--- a/src/SmartList/components/Header/Header.tsx
+++ b/src/SmartList/components/Header/Header.tsx
@@ -97,6 +97,7 @@ const Header: React.FC<IProps> = ({ cols, selectAllCol, onSelectAll }) => {
     >
       {selectAllCol && <Col
         key='select-all-col'
+        width={1}
        >
          <input
            type='checkbox'
@@ -109,6 +110,7 @@ const Header: React.FC<IProps> = ({ cols, selectAllCol, onSelectAll }) => {
       {cols.map((x, idx) => 
         <Col 
           data-testid={`header-column-${x.name}`}
+          width={x.width}
           key={x.name}
           onClick={() => sortable(x) && handleSortButtonClicked(x, idx)}
           className={sortable(x) ? 'cursor-pointer' : ''}

--- a/src/SmartList/components/Header/types.ts
+++ b/src/SmartList/components/Header/types.ts
@@ -2,7 +2,6 @@ import { IHeaderItem } from '../../../types'
 
 export interface IProps {
   cols: IHeaderItem[]
-  onSort?: (colIndex: number, ascending: boolean) => void
   selectAllCol?: boolean
   onSelectAll?: (checked: boolean) => void
 }

--- a/src/SmartList/components/ListItem/ListItem.tsx
+++ b/src/SmartList/components/ListItem/ListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Row, Col } from '../../../Grid'
 
-import { IColumnElement } from '../../../types'
+import { IColumnElement, IHeaderItem } from '../../../types'
 import '../../index.scss'
 
 interface IProps {
@@ -14,6 +14,7 @@ interface IProps {
   selected?: boolean
   onSelect?: (id: string | number, newState: boolean) => void
   disabled?: boolean
+  cols?: IHeaderItem[]
 }
 
 const ListItem: React.FC<IProps> = (props: IProps) => {
@@ -51,6 +52,7 @@ const ListItem: React.FC<IProps> = (props: IProps) => {
     >
       {
         selectable && <Col
+          width={1}
           key={`list-select-${rowId}`}
           data-testid={`check-col-${rowId}`}
         >
@@ -64,10 +66,11 @@ const ListItem: React.FC<IProps> = (props: IProps) => {
         </Col>
       }
       {
-        columns.map(x =>
+        columns.map((x, idx) =>
           <Col 
             key={x.name}
             data-test={x.name}
+            width={props.cols && props.cols[idx].width}
           >
             {x.element || x.text}
           </Col>

--- a/src/SmartList/components/ListItem/ListItem.tsx
+++ b/src/SmartList/components/ListItem/ListItem.tsx
@@ -9,7 +9,8 @@ interface IProps {
   rowId: number | string
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => any
   className?: string
-  selectable?: boolean // backwards compatibilty < 0.9.0
+  isActive?: boolean
+  selectable?: boolean
   selected?: boolean
   onSelect?: (id: string | number, newState: boolean) => void
   disabled?: boolean
@@ -19,6 +20,7 @@ const ListItem: React.FC<IProps> = (props: IProps) => {
   const {
     columns,
     onClick,
+    isActive,
     selectable,
     selected,
     onSelect,
@@ -32,8 +34,8 @@ const ListItem: React.FC<IProps> = (props: IProps) => {
 
   let className = `list-row align-items-center ${props.className || ''}`
 
-  if (selected) {
-    className += 'selected '
+  if (isActive) {
+    className += 'active-row '
   }
 
   if (onClick || selectable) {

--- a/src/SmartList/components/ListItem/index.ts
+++ b/src/SmartList/components/ListItem/index.ts
@@ -1,0 +1,5 @@
+import { ListItem } from './ListItem'
+
+export {
+  ListItem
+}

--- a/src/SmartList/index.scss
+++ b/src/SmartList/index.scss
@@ -38,7 +38,7 @@
   right: -15px;
 }
 
-.selected {
+.active-row {
   background: $list-selected;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,8 @@ export interface IHeaderItem {
   name: string
   displayName?: string
   className?: string
-  sortable?: boolean
   width?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
-  handleSort?: (column: string) => void
+  handleSort?: (colIndex: number, ascending: boolean) => void
 }
 
 export interface IColumnElement {


### PR DESCRIPTION
Added as part of this PR:
- Support for column specific sort functions rather than one sort function for the entire list
- Active row state separate from multi-selectable state

