### PR TITLE
Add CJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cohesive-ui",
   "version": "1.3.0",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cohesive-ui.cjs.js",
+  "module": "dist/cohesive-ui.esm.js",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,32 +1,41 @@
 import typescript from 'rollup-plugin-typescript2'
 import sass from 'rollup-plugin-sass'
 
-export default {
-  input: './src/index.ts',
-  output: {
-    file: './dist/index.js',
-    format: 'es',
-  },
-  external: [
-    'react',
-    'react-bootstrap',
-    'react-bootstrap/Row',
-    'react-bootstrap/Col',
-    'react-bootstrap/ListGroup',
-    '@fortawesome/react-fontawesome',
-    '@fortawesome/free-solid-svg-icons',
-    'react-bootstrap/Form',
-    'react-bootstrap/InputGroup',
-    'react-bootstrap/Button',
-    'react-bootstrap/OverlayTrigger',
-    'react-bootstrap/Tooltip',
-    'react-bootstrap/Navbar',
-    'moment',
-  ],
-  plugins: [
-    typescript(),
-    sass({
-      output: true
-    })
-  ]
+const createEntry = ({ format, file }) => {
+  const config = {
+    input: './src/index.ts',
+    output: {
+      file: './dist/' + file,
+      format,
+    },
+    external: [
+      'react',
+      'react-bootstrap',
+      'react-bootstrap/Row',
+      'react-bootstrap/Col',
+      'react-bootstrap/ListGroup',
+      '@fortawesome/react-fontawesome',
+      '@fortawesome/free-solid-svg-icons',
+      'react-bootstrap/Form',
+      'react-bootstrap/InputGroup',
+      'react-bootstrap/Button',
+      'react-bootstrap/OverlayTrigger',
+      'react-bootstrap/Tooltip',
+      'react-bootstrap/Navbar',
+      'moment',
+    ],
+    plugins: [
+      typescript(),
+      sass({
+        output: true
+      })
+    ]
+  }
+
+  return config
 }
+
+export default [
+  createEntry({ format: 'es', file: 'cohesive-ui.esm.js' }),
+  createEntry({ format: 'cjs', file: 'cohesive-ui.cjs.js' }),
+]


### PR DESCRIPTION
We were only building for ES modules (`import`/`export` syntax). Now we build for commonjs aka CJS aka node.js modules (`require` syntax).

This is needed mainly for tests, since Jest does not understand ES modules by default.

I can explain more if needed. Ideally we will also include an IIFE build, but not right now.