### PR TITLE
include-colors include colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "classnames": "^2.2.6"
   },
   "scripts": {
-    "build": "rm -rf dist && yarn rollup -c rollup.config.js && cp -r src/style/colors.scss dist/style/colors.scss && cp src/style/global.css dist/style/global.css",
+    "build": "rm -rf dist && yarn rollup -c rollup.config.js && cp -r src/style/colors.scss dist/style/colors.scss && cp src/style/global.css dist/style/global.css && cp src/style/colors.ts dist/style/colors.ts",
     "build-storybook": "build-storybook -c .storybook -o docs",
     "test": "jest",
     "storybook": "start-storybook -p 6006  -s ./src"


### PR DESCRIPTION
Looks like `style/colors.ts` is are not included by rollup during the build step 🤔 

Just include them manually for now.