### PR TITLE
Feature/ui 36 dropdown validation

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -21,12 +21,6 @@ const content = (
 )
 
 
-const searchIcon = (
-  <FontAwesomeIcon
-    icon={faSearch}
-  />
-)
-
 stories.add('Components.Dropdown', () => {
   return (
     <div style={{ maxWidth: '500px' }}>
@@ -42,7 +36,6 @@ stories.add('Components.Dropdown', () => {
             {label: 'Hospital C', value: '3'}
           ]}
           onSelect={noop}
-          searchIcon={searchIcon}
         />
       </div>
 
@@ -68,7 +61,6 @@ stories.add('Components.Dropdown', () => {
             {label: 'Hospital L', value: '12'}
           ]}
           onSelect={noop}
-          searchIcon={searchIcon}
         />
       </div>
 
@@ -99,8 +91,7 @@ stories.add('Components.Dropdown', () => {
             {label: 'Hospital C', value: '3'}
           ]}
           onSelect={noop}
-          searchIcon={searchIcon}
-          defaultIndex={2}
+          defaultValue='2'
         />
       </div>
 
@@ -118,7 +109,6 @@ stories.add('Components.Dropdown', () => {
             {label: 'Hospital C', value: '3'}
           ]}
           onSelect={noop}
-          searchIcon={searchIcon}
         />
       </div>
 
@@ -136,7 +126,24 @@ stories.add('Components.Dropdown', () => {
             {label: 'Hospital C', value: '3'}
           ]}
           onSelect={noop}
-          searchIcon={searchIcon}
+        />
+      </div>
+
+      <hr />
+
+      <h3 className='m-5'>Error on blur with nothing selected</h3>
+      <div className='m-5'>
+        <Dropdown 
+          id='withLabel'
+          label='Select a Hospital'
+          placeholder='Select Hospital'
+          isRequired
+          data={[
+            {value: '1'},
+            {label: 'Hospital B', value: '2'},
+            {label: 'Hospital C', value: '3'}
+          ]}
+          onSelect={noop}
         />
       </div>
     </div>

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -89,6 +89,10 @@ const Dropdown: React.FC<IProps> = ({ id, className, children, label, isRequired
     if (onBlur) {
       onBlur(item, true)
     }
+
+    if (onSelect) {
+      onSelect(item)
+    }
   }
 
   const listItems = (items: IDropdownItem[]) => (

--- a/src/Dropdown/index.scss
+++ b/src/Dropdown/index.scss
@@ -48,6 +48,18 @@ ul.co-dropdown-list {
   border-radius: 5px;
 }
 
+.co-dropdown-invalid {
+  border: 1px solid red;
+}
+
+.form-field-label-invalid {
+  color: red;
+}
+
+.co-dropdown-label {
+  margin: 0;
+}
+
 .co-dropdown {
   background: $lightest-grey;
   position: absolute;

--- a/src/Dropdown/index.ts
+++ b/src/Dropdown/index.ts
@@ -1,5 +1,1 @@
-import { Dropdown } from './Dropdown'
-
-export {
-  Dropdown
-}
+export * from './Dropdown'


### PR DESCRIPTION
- Validation on blur
- moved test to testing library since this is what we are using everywhere else.
- pass full `IDropdownItem` in `onBlur` callback, not just the value
- there is still something confusing. All other inputs do `onBlur` with a payload of `value, valid`. I added it here too for consistency. we also have `onSelect` which just passes `value`. this seems a little weird but I guess it makes sense? I would expect a dropdown to have a `onSelect` prop - and I also expect `onBlur` so it's in line with our other components. Thoughts?

![image](https://user-images.githubusercontent.com/19196536/83106836-7e582800-a100-11ea-9ecb-2a41a3363044.png)
