### PR TITLE
UI-39 support float types

### DIFF
--- a/src/DateInput/validation.spec.ts
+++ b/src/DateInput/validation.spec.ts
@@ -12,7 +12,7 @@ describe('validate', () => {
 
     const expected: IValidationResult = {
       valid: false,
-      message: 'This field is required',
+      message: 'Required',
     }
 
     const actual = validate(rules, '')

--- a/src/DateInput/validation.ts
+++ b/src/DateInput/validation.ts
@@ -13,7 +13,7 @@ export interface IValidationResult {
 const validate = (rules: IValidators, text: string): IValidationResult => {
   if (rules.isRequired && (!text.length || moment(text, 'YYYY-MM-DD').toString() === 'Invalid date')) {
     return {
-      message: 'This field is required',
+      message: 'Required',
       valid: false
     }
   }

--- a/src/Form/TextInput/validation.spec.ts
+++ b/src/Form/TextInput/validation.spec.ts
@@ -13,7 +13,7 @@ describe('validate', () => {
 
     const expected: IValidationResult = {
       valid: false,
-      message: 'This field is required',
+      message: 'Required',
     }
 
     const actual = validate(rules, '')

--- a/src/Form/TextInput/validation.ts
+++ b/src/Form/TextInput/validation.ts
@@ -18,7 +18,7 @@ const validate = (rules: IValidators, text: string): IValidationResult => {
 
   if (rules.isRequired && !text.length) {
     return {
-      message: 'This field is required',
+      message: 'Required',
       valid: false,
     }
   }

--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -4,7 +4,7 @@ import { validate } from './validation'
 import '../shared/input.scss'
 
 
-export type TNumberType = 'whole' | 'integer'
+export type TNumberType = 'whole' | 'integer' | 'positiveFloat'
 
 interface IProps {
   label?: string

--- a/src/NumberInput/validation.spec.ts
+++ b/src/NumberInput/validation.spec.ts
@@ -12,7 +12,7 @@ describe('validate', () => {
 
   const invalid: IValidationResult = {
     valid: false,
-    message: 'Only whole numbers are allowed',
+    message: 'Whole numbers only',
   }
 
   test('isWhole invalid', () => {
@@ -32,7 +32,7 @@ describe('validate', () => {
 
   test('isRequired invalid', () => {
     const actual = validate({ type: 'whole', isRequired: true }, '')
-    expect(actual).toEqual({ valid: false, message: 'This field is required' })
+    expect(actual).toEqual({ valid: false, message: 'Required' })
   })
 
   test('isWhole valid', () => {
@@ -47,7 +47,7 @@ describe('validate', () => {
 
   test('isInteger invalid', () => {
     const actual = validate({ type: 'integer' }, '0.1')
-    expect(actual).toEqual({ valid: false, message: 'Only integers are allowed' })
+    expect(actual).toEqual({ valid: false, message: 'Integers only' })
   })
 
   test('isInteger valid', () => {
@@ -58,5 +58,25 @@ describe('validate', () => {
   test('isInteger valid', () => {
     const actual = validate({ type: 'integer' }, '1')
     expect(actual).toEqual({ valid: true })
+  })
+
+  test('isFloat valid', () => {
+    const actual = validate({ type: 'positiveFloat' }, '1')
+    expect(actual).toEqual({ valid: true })
+  })
+
+  test('isFloat valid', () => {
+    const actual = validate({ type: 'positiveFloat' }, '1.0')
+    expect(actual).toEqual({ valid: true })
+  })
+
+  test('isFloat valid', () => {
+    const actual = validate({ type: 'positiveFloat' }, '0')
+    expect(actual).toEqual({ valid: true })
+  })
+
+  test('isFloat valid', () => {
+    const actual = validate({ type: 'positiveFloat' }, '-1.2')
+    expect(actual).toEqual({ valid: false, message: 'Positive numbers only' })
   })
 })

--- a/src/NumberInput/validation.ts
+++ b/src/NumberInput/validation.ts
@@ -21,24 +21,36 @@ const isInteger = (str: string): boolean => {
   return n !== Infinity && String(n) === str
 }
 
+const isPositiveFloat = (str: string): boolean => {
+  const n = parseFloat(str)
+  return !isNaN(n) && n >= 0
+}
+
 const validate = (rules: IValidators, text: string): IValidationResult => {
   if (rules.isRequired && !text.length) {
     return {
-      message: 'This field is required',
+      message: 'Required',
       valid: false,
     }
   }
 
   if (rules.type === 'whole' && !isWhole(text)) {
     return {
-      message: 'Only whole numbers are allowed',
+      message: 'Whole numbers only',
       valid: false,
     }
   }
 
   if (rules.type === 'integer' && !isInteger(text)) {
     return {
-      message: 'Only integers are allowed',
+      message: 'Integers only',
+      valid: false,
+    }
+  }
+
+  if (rules.type === 'positiveFloat' && !isPositiveFloat(text)) {
+    return {
+      message: 'Positive numbers only',
       valid: false,
     }
   }

--- a/src/TextInput/TextInput.spec.tsx
+++ b/src/TextInput/TextInput.spec.tsx
@@ -22,12 +22,12 @@ describe('TextInput', () => {
     // type some text and blur - input is valid
     fireEvent.change(screen.getByTestId('my-input'), { target: { value: 'value' } })
     fireEvent.blur(screen.getByTestId('my-input'))
-    expect(screen.queryByTestId(/This field is required/)).toBeNull()
+    expect(screen.queryByTestId(/Required/)).toBeNull()
 
     // set to empty string and blur - now the input is invalid
     fireEvent.change(screen.getByTestId('my-input'), { target: { value: '' } })
     fireEvent.blur(screen.getByTestId('my-input'))
 
-    expect(screen.queryByText(/This field is required/)).toBeInTheDocument()
+    expect(screen.queryByText(/Required/)).toBeInTheDocument()
   })
 })

--- a/src/TextInput/validation.spec.ts
+++ b/src/TextInput/validation.spec.ts
@@ -13,7 +13,7 @@ describe('validate', () => {
 
     const expected: IValidationResult = {
       valid: false,
-      message: 'This field is required',
+      message: 'Required',
     }
 
     const actual = validate(rules, '')

--- a/src/TextInput/validation.ts
+++ b/src/TextInput/validation.ts
@@ -22,7 +22,7 @@ const validate = (rules: IValidators, text: string): IValidationResult => {
 
   if (rules.isRequired && !text.length) {
     return {
-      message: 'This field is required',
+      message: 'Required',
       valid: false,
     }
   }


### PR DESCRIPTION
Support float validation. Don't think we need negative floats - we don't allow negative numbers anywhere from what I can see.

Also simplified error messages in general by Callum's recommendation.