### PR TITLE
UI-40 add confirm modal

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -3,7 +3,7 @@
 @mixin button($color) {
   background: $color;
   border: 1px solid;
-  height: 32px;
+  height: 34px;
   display: flex;
   align-items: center;
   line-height: 0.5;
@@ -49,7 +49,7 @@
 }
 
 .btn-danger {
-  @include button($see);
+  @include button(red);
 }
 
 .btn-warning {
@@ -66,6 +66,7 @@
 
 .btn-light {
   @include button($lightgrey);
+  color: black;
 }
 
 

--- a/src/ConfirmModal/ConfirmModal.spec.tsx
+++ b/src/ConfirmModal/ConfirmModal.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from '@testing-library/react'
+
+import { ConfirmModal } from './ConfirmModal'
+ 
+
+describe('ConfirmModal', () => {
+  it('changes between selected items', () => {
+    const onCancel = jest.fn()
+    const onConfirm = jest.fn()
+    render(<ConfirmModal entityType='patient' onCancel={onCancel} onConfirm={onConfirm}  />)
+
+    fireEvent.click(screen.getByText(/Erase this patient/))
+    fireEvent.click(screen.getByText(/Cancel/))
+
+    expect(onConfirm).toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/src/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { ConfirmModal } from './ConfirmModal'
+
+const stories = storiesOf('Components.Modals.ConfirmModal', module)
+
+stories.add('Layout with Navigation', () => {
+  return (
+    <ConfirmModal 
+      entityType='Patient'
+      onCancel={() => {}}
+      onConfirm={() => {}}
+    />
+  )
+})

--- a/src/ConfirmModal/ConfirmModal.tsx
+++ b/src/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+// import { faTrash } from '@fortawesome/free-solid-svg-icons'
+
+import { Container, Row, Col } from '../Grid'
+import { Button } from '../Button'
+import './index.scss'
+
+import './index.scss'
+import { TrashFill } from '../Icons/TrashFill'
+
+interface IProps {
+  entityType: string
+  entityName?: string
+  onCancel: () => any
+  onConfirm: () => any
+}
+
+const capitalizeString = (str: string) => {
+  return str.replace(/^\w/, c => c.toUpperCase())
+}
+
+const ConfirmModal: React.FC<IProps> = (props) => {
+  return (
+    <div data-testid='confirm-modal' className='confirm-modal'>
+      <Container>
+        <Row>
+
+          <Col width={2}>
+            <TrashFill height={50} width={50} />
+          </Col>
+
+          <Col>
+            <h4 className='co-h4 pb-2'>Delete {capitalizeString(props.entityType)}</h4>
+            <div className='confirm-subtitle'>{props.entityName || ''}</div>
+            <div>
+              The selected {props.entityType}(s) will be permanently deleted from the system.<br />
+              This action cannot be undone.
+            </div>
+          </Col>
+
+          <Col width={2}>
+          </Col>
+        </Row>
+
+        <Row className='buttons'>
+          <Col>
+            <div className='d-flex justify-content-end'>
+              <Button
+                data-testid='confirm-modal-cancel'
+                variant='light'
+                className='mr-3'
+                onClick={props.onCancel}
+              >
+                Cancel
+              </Button>
+              <Button
+                data-testid='confirm-modal-confirm'
+                variant='danger'
+                onClick={props.onConfirm}
+              >
+                Erase this {(props.entityType)}
+              </Button>
+            </div>
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  )
+}
+
+export {
+  ConfirmModal
+}

--- a/src/ConfirmModal/ConfirmModal.tsx
+++ b/src/ConfirmModal/ConfirmModal.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
-// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-// import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
+import { TrashFill } from '../Icons/TrashFill'
 import { Container, Row, Col } from '../Grid'
 import { Button } from '../Button'
 import './index.scss'
-
-import './index.scss'
-import { TrashFill } from '../Icons/TrashFill'
 
 interface IProps {
   entityType: string

--- a/src/ConfirmModal/index.scss
+++ b/src/ConfirmModal/index.scss
@@ -1,0 +1,29 @@
+.confirm-modal {
+  border-top: 6px solid red;
+  background-color: white;
+  margin-top: 150px;
+
+  button {
+    text-transform: uppercase;
+  }
+  
+  .delete-icon {
+    color: red;
+  }
+
+  width: 538px;
+  padding: 25px 15px;
+
+  .buttons {
+    margin-top: 25px;
+
+    .btn {
+      margin-left: 15px;
+    }
+  }
+}
+
+.confirm-subtitle {
+  font-size: 1.1rem;
+  margin-bottom: 10px;
+}

--- a/src/Icons/TrashFill.tsx
+++ b/src/Icons/TrashFill.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 
-const TrashFill: React.FC = () => {
+interface IProps {
+  height?: number
+  width?: number
+}
+
+const TrashFill: React.FC<IProps> = (props) => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width={props.width || 24} height={props.height || 24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <g id="Trash/trash-hover-fill">
         <g id="Trash button :hover Copy">
           <g id="Trash/MASTER-trash-default">

--- a/src/Modal/Modal.spec.tsx
+++ b/src/Modal/Modal.spec.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from '@testing-library/react'
+
+import { Modal } from './Modal'
+ 
+
+describe('Modal', () => {
+  it('changes between selected items', () => {
+    const Wrapper = () => {
+      const [show, setShow] = useState(true)
+      return <Modal show={show} onHide={() => setShow(false)}>Text</Modal>
+    }
+
+    render(<Wrapper />)
+
+    expect(screen.queryByText(/Text/)).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('overlay'))
+
+    expect(screen.queryByText(/Text/)).not.toBeInTheDocument()
+  })
+})

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import { Modal } from './Modal'
+import { Button } from '../Button'
+import { ConfirmModal } from '../ConfirmModal/ConfirmModal'
+
+const stories = storiesOf('Components.Modals.Modal', module)
+
+stories.add('Layout with Navigation', () => {
+  const Comp = () => {
+    const [show, setShow] = useState(false)
+
+    return (
+      <>
+        <Modal show={show} onHide={() => setShow(false)}>
+          <ConfirmModal 
+            entityType='patient'
+            onCancel={() => setShow(false)}
+            onConfirm={() => setShow(false)}
+          />
+        </Modal>
+
+        <Button onClick={() => setShow(true)} variant='primary'>Show Modal</Button>
+      </>
+    )
+  }
+
+  return (
+    <Comp />
+  )
+})

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import './index.scss'
+
+interface IProps {
+  show: boolean
+  onHide?: () => any
+}
+
+const Modal: React.FC<IProps> = (props) => {
+  const handleClose = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      (e.nativeEvent.target as HTMLDivElement).classList.contains('overlay') &&
+      props.onHide
+    ) {
+      props.onHide()
+    }
+  }
+
+  if (!props.show) {
+    return <></>
+  }
+
+  return (
+    <div
+      className='overlay regular-overlay'
+      data-testid='overlay'
+      onClick={handleClose}
+    >
+      <div id='modal-body'>
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+export {
+  Modal
+}

--- a/src/Modal/index.scss
+++ b/src/Modal/index.scss
@@ -1,0 +1,20 @@
+@import '../style/colors.scss';
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.regular-overlay {
+  z-index: 1050;
+
+  #modal-body {
+    position: absolute;
+  }
+}


### PR DESCRIPTION
Added `<Modal>` which you can use to render anything as a modal. Also added `<ConfirmModal>` which you use like this:

```
<Modal>
  <ConfirmModal />
</Modal>
```

Seems the most flexible.

![image](https://user-images.githubusercontent.com/19196536/83224390-a73ff200-a1c0-11ea-8ba8-6e3c086b0353.png)
