### PR TITLE
Remove outline for IconButton

### DIFF
--- a/src/IconButton/index.scss
+++ b/src/IconButton/index.scss
@@ -6,3 +6,7 @@
   font-size: 12px;
   cursor: pointer;
 }
+
+.icon-button:focus {
+  outline: none !important
+}


### PR DESCRIPTION
Reducing its size proved to be too difficult, especially with cross browser taken into consideration.