### PR TITLE
Feature/ui 55 action buttons + mobile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohesive-ui",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "dist/cohesive-ui.cjs.js",
   "module": "dist/cohesive-ui.esm.js",
   "files": [

--- a/src/ActionButton/ActionButton.stories.tsx
+++ b/src/ActionButton/ActionButton.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { ActionButton, TActionButtonType } from './ActionButton'
+
+const types: TActionButtonType[] = ['archive', 'edit', 'unarchive', 'delete']
+
+const createActionButton = (type: TActionButtonType, options?: { disabled: boolean }) => {
+  return (
+    <ActionButton actionType={type} disabled={options?.disabled} />
+  )
+}
+storiesOf('Components.ActionButton', module)
+  .add('Various Colors and Shapes', () => {
+    return (
+      <React.Fragment>
+        {types.map(type => {
+          return (
+            <div>
+              {createActionButton(type)}
+              {createActionButton(type, { disabled: true })}
+            </div>
+          )
+        })}
+  
+      </React.Fragment>
+    )
+  })

--- a/src/ActionButton/ActionButton.tsx
+++ b/src/ActionButton/ActionButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { ListButton } from '../ListButton'
+import { Unarchive, Archive, Trash, Edit } from '../Icons'
+import './index.scss'
+
+export type TActionButtonType = 'archive' | 'unarchive' | 'delete' | 'edit'
+
+interface IActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  actionType: TActionButtonType
+  disabled?: boolean
+}
+
+const capitalize = (str: string) => {
+  return str[0].toUpperCase() + str.slice(1)
+}
+
+export const ActionButton: React.FC<IActionButtonProps> = props => {
+  let icon: JSX.Element
+  if (props.actionType === 'archive') {
+    icon = <Archive />
+  }
+  if (props.actionType === 'unarchive') {
+    icon = <Unarchive />
+  }
+  if (props.actionType === 'delete') {
+    icon = <Trash />
+  }
+  if (props.actionType === 'edit') {
+    icon = <Edit />
+  }
+
+  const { actionType, ...rest } = props
+  return (
+    <ListButton
+      {...rest}
+      className={classnames(
+        'co-action-button', 
+        `co-action-${props.actionType}-button`, {
+        'co-action-button-disabled': props.disabled,
+        [`co-action-${props.actionType}-button-active`]: !props.disabled
+      })}
+    >
+      <div className='d-flex align-items-center'>
+        {icon!}
+        <div className={`co-action-${props.actionType}-text`}>
+          {capitalize(props.actionType)}
+        </div>
+      </div>
+    </ListButton>
+  )
+}

--- a/src/ActionButton/index.scss
+++ b/src/ActionButton/index.scss
@@ -1,0 +1,69 @@
+.co-action-button {
+  height: 32px;
+  padding: 5px 14px 9px 14px !important;
+  display: block !important;
+
+  svg {
+    box-sizing: content-box;
+    margin: 0 7px 0 0;
+  }
+}
+
+@mixin colored-svg($fill-color) {
+  svg {
+    rect.is-outline {
+      fill: $fill-color;
+    }
+    path.is-outline {
+      fill: $fill-color;
+    }
+  }
+}
+
+.co-action-archive-button {
+  svg { padding: 0 0 1px 0; }
+}
+
+.co-action-unarchive-button {
+  svg { padding: 0 0 2px 0; }
+}
+
+.co-action-delete-button {
+  svg { padding: 0 0 2px 0; }
+}
+
+.co-action-button-disabled {
+  @include colored-svg(silver);
+  height: 34px;
+}
+
+.co-action-archive-button-active {
+  &:hover {
+    @include colored-svg(#777777);
+    border: 1px solid rgba(0, 0, 0, 0.16) !important;
+  }
+}
+
+.co-action-unarchive-button-active {
+  &:hover {
+    @include colored-svg(#5B7FA5);
+    border: 1px solid #D4DAE7 !important;
+    box-shadow: 0px 3px 8px rgba(18, 50, 120, 0.18);
+  }
+}
+
+.co-action-edit-button-active {
+  &:hover {
+    @include colored-svg(#33ABB4);
+    border: 1px solid rgba(14, 91, 97, 0.18) !important;
+    box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
+  }
+}
+
+.co-action-delete-button-active {
+  &:hover {
+    @include colored-svg(red);
+    border: 1px solid rgba(129, 8, 11, 0.3);
+    box-shadow: 0px 3px 6px rgba(102, 8, 10, 0.18) !important;
+  }
+}

--- a/src/ActionButton/index.ts
+++ b/src/ActionButton/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionButton'

--- a/src/ConfirmModal/index.scss
+++ b/src/ConfirmModal/index.scss
@@ -1,7 +1,15 @@
+@import '../style/media.scss';
+
 .confirm-modal {
   border-top: 6px solid red;
   background-color: white;
   margin-top: 150px;
+  width: 538px;
+  padding: 25px 15px;
+
+  @include mobile-only {
+    width: 100%;
+  }
 
   button {
     text-transform: uppercase;
@@ -10,9 +18,6 @@
   .delete-icon, .co-confirm-modal-error {
     color: red;
   }
-
-  width: 538px;
-  padding: 25px 15px;
 
   .buttons {
     margin-top: 25px;

--- a/src/Icons/Archive.tsx
+++ b/src/Icons/Archive.tsx
@@ -4,8 +4,8 @@ import { IconProps } from './'
 const Archive: React.FC<IconProps & React.HTMLAttributes<HTMLOrSVGElement>> = (props) => {
   return (
     <svg {...props} width="14" height="13" viewBox="0 0 14 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect width="14" height="3" fill={props.background || '#AEAEAE'} />
-      <path fillRule="evenodd" clipRule="evenodd" d="M1 4H13V13H1V4Z" fill={props.background || '#AEAEAE'} />
+      <rect className='is-outline' width="14" height="3" fill={props.background || '#AEAEAE'} />
+      <path className='is-outline'fillRule="evenodd" clipRule="evenodd" d="M1 4H13V13H1V4Z" fill={props.background || '#AEAEAE'} />
       <rect x="5" y="6" width="4" height="2" fill="white"/>
     </svg>
   )

--- a/src/Icons/Edit.tsx
+++ b/src/Icons/Edit.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { IconProps } from './'
+
+const Edit: React.FC<IconProps & React.HTMLAttributes<HTMLOrSVGElement>> = (props) => {
+  return (
+    <svg {...props} width="15" height="22" viewBox="0 0 15 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path className='is-outline' fillRule="evenodd" clipRule="evenodd" d="M8.39868 14.5534L4.93458 12.5534L3.14984 18.8692C3.03698 19.2686 3.53198 19.5544 3.82143 19.2569L8.39868 14.5534Z" fill="#AEAEAE" />
+      <path className='is-outline' fillRule="evenodd" clipRule="evenodd" d="M14.732 3.58377C15.2843 2.62718 14.9565 1.404 14 0.851718C13.0434 0.299433 11.8202 0.627185 11.2679 1.58377L11.0207 2.01197L14.4848 4.01197L14.732 3.58377ZM13.8181 5.16668L10.354 3.16668L4.93457 12.5534L8.39867 14.5534L13.8181 5.16668Z" fill="#AEAEAE" />
+    </svg>
+  )
+}
+
+export {
+  Edit
+}
+

--- a/src/Icons/Final/Archive/index.scss
+++ b/src/Icons/Final/Archive/index.scss
@@ -1,15 +1,8 @@
 .co-archive {
-  border: 1px solid transparent;
-  border-radius: 50%;
   box-sizing: border-box;
-  fill: #AEAEAE;
-}
-
-.co-archive {
-  &:hover {
-    fill: #777777;
-    background: rgba(14, 91, 97, 0.18);
-    border: 1px solid rgba(14, 91, 97, 0.18);
-    box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
-  }
+  border-radius: 50%;
+  fill: #777777;
+  background: rgba(14, 91, 97, 0.18);
+  border: 1px solid rgba(14, 91, 97, 0.18);
+  box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
 }

--- a/src/Icons/Final/Delete/index.scss
+++ b/src/Icons/Final/Delete/index.scss
@@ -1,13 +1,8 @@
 .co-delete {
-  border: 1px solid transparent;
   border-radius: 50%;
   box-sizing: border-box;
-  fill: #AEAEAE;
-
-  &:hover {
-    fill: red;
-    background: rgba(129, 8, 11, 0.14);
-    border: 1px solid rgba(129, 8, 11, 0.14);
-    box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
-  }
+  fill: red;
+  background: rgba(129, 8, 11, 0.14);
+  border: 1px solid rgba(129, 8, 11, 0.14);
+  box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
 }

--- a/src/Icons/Final/Edit/index.scss
+++ b/src/Icons/Final/Edit/index.scss
@@ -1,13 +1,9 @@
 .co-edit {
-  border: 1px solid transparent;
   border-radius: 50%;
   box-sizing: border-box;
-  fill: #AEAEAE;
+  fill: #33ABB4;
 
-  &:hover {
-    fill: #33ABB4;
-    background: rgba(14, 91, 97, 0.18);;
-    border: 1px solid rgba(14, 91, 97, 0.18);
-    box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
-  }
+  background: rgba(14, 91, 97, 0.18);;
+  border: 1px solid rgba(14, 91, 97, 0.18);
+  box-shadow: 0px 3px 6px rgba(17, 107, 114, 0.18);
 }

--- a/src/Icons/Final/Unarchive/index.scss
+++ b/src/Icons/Final/Unarchive/index.scss
@@ -1,13 +1,8 @@
 .co-unarchive {
-  border: 1px solid transparent;
   border-radius: 50%;
   box-sizing: border-box;
-  fill: #AEAEAE;
-
-  &:hover {
-    fill: #5B7FA5;
-    background: rgba(14, 91, 97, 0.18);
-    border: 1px solid #D4DAE7;
-    box-shadow: 0px 3px 6px rgba(18, 50, 120, 0.18);
-  }
+  fill: #5B7FA5;
+  background: rgba(14, 91, 97, 0.18);
+  border: 1px solid #D4DAE7;
+  box-shadow: 0px 3px 6px rgba(18, 50, 120, 0.18);
 }

--- a/src/Icons/Final/index.scss
+++ b/src/Icons/Final/index.scss
@@ -1,5 +1,6 @@
 .co-icon-button {
   outline: none;
+  height: 32px;
 
   .co-icon-disabled {
     opacity: 0.5;

--- a/src/Icons/Final/index.scss
+++ b/src/Icons/Final/index.scss
@@ -3,13 +3,10 @@
 
   .co-icon-disabled {
     opacity: 0.5;
-
-    &:hover {
-      fill: #AEAEAE;
-      border: 1px solid white;
-      box-shadow: none;
-      opacity: 0.5 !important;
-      cursor: not-allowed;
-    }
+    fill: #AEAEAE;
+    cursor: not-allowed;
+    border: none;
+    background: none;
+    box-shadow: none;
   } 
 }

--- a/src/Icons/Trash.tsx
+++ b/src/Icons/Trash.tsx
@@ -5,9 +5,9 @@ import { IconProps } from './'
 const Trash: React.FC<IconProps & React.HTMLAttributes<HTMLOrSVGElement>> = (props) => {
   return (
     <svg {...props} width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0.333008" y="1.33331" width="13.3333" height="2.66667" fill={props.background || "#AEAEAE"}/>
-      <rect x="5.66699" width="2.66667" height="1.33333" fill={props.background || "#AEAEAE"} />
-      <path fillRule="evenodd" clipRule="evenodd" d="M1.66699 4H12.3337L10.9774 16H2.98621L1.66699 4Z" fill={props.background || "#AEAEAE"} />
+      <rect className='is-outline' x="0.333008" y="1.33331" width="13.3333" height="2.66667" fill={props.background || "#AEAEAE"}/>
+      <rect className='is-outline' x="5.66699" width="2.66667" height="1.33333" fill={props.background || "#AEAEAE"} />
+      <path className='is-outline' fillRule="evenodd" clipRule="evenodd" d="M1.66699 4H12.3337L10.9774 16H2.98621L1.66699 4Z" fill={props.background || "#AEAEAE"} />
     </svg>
   )
 }

--- a/src/Icons/Unarchive.tsx
+++ b/src/Icons/Unarchive.tsx
@@ -4,8 +4,8 @@ import { IconProps } from './'
 export const Unarchive: React.FC<IconProps & React.HTMLAttributes<HTMLOrSVGElement>> = (props) => {
   return (
     <svg {...props} width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="1.62695" y="0.23938" width="14" height="3" transform="rotate(15 1.62695 0.23938)" fill={props.background || '#AEAEAE'} />
-      <path fillRule="evenodd" clipRule="evenodd" d="M1 7H13V16H1V7Z" fill={props.background || '#AEAEAE'} />
+      <rect className='is-outline' x="1.62695" y="0.23938" width="14" height="3" transform="rotate(15 1.62695 0.23938)" fill={props.background || '#AEAEAE'} />
+      <path className='is-outline' fillRule="evenodd" clipRule="evenodd" d="M1 7H13V16H1V7Z" fill={props.background || '#AEAEAE'} />
       <rect x="5" y="9" width="4" height="2" fill="white"/>
     </svg>
   )

--- a/src/Icons/index.ts
+++ b/src/Icons/index.ts
@@ -4,6 +4,7 @@ export interface IconProps {
 
 export * from './ThinSpinner'
 export * from './Final/Archive'
+export * from './Edit'
 export * from './Archive'
 export * from './Unarchive'
 export * from './Final/Unarchive'

--- a/src/ListButton/ListButton.stories.tsx
+++ b/src/ListButton/ListButton.stories.tsx
@@ -10,6 +10,26 @@ storiesOf('Components.ListButton', module)
     return (
       <div>
         <ListButton
+          size='sm'
+        >
+          <span className='d-flex'>
+            <Archive className='px-2' />
+            <span>sm</span>
+          </span>
+        </ListButton>
+        <br /><br />
+
+        <ListButton
+          size='md'
+        >
+          <span className='d-flex'>
+            <Archive className='px-2' />
+            <span>md</span>
+          </span>
+        </ListButton>
+        <br /><br />
+
+        <ListButton
           disabled={true}
         >
           <span className='d-flex'>
@@ -17,7 +37,6 @@ storiesOf('Components.ListButton', module)
             <span>Disabled State</span>
           </span>
         </ListButton>
-
         <br /><br />
 
         <ListButton
@@ -26,6 +45,15 @@ storiesOf('Components.ListButton', module)
           <span className='d-flex'>
             <Archive className='px-2' />
             <span>Enabled (5) State</span>
+          </span>
+        </ListButton>
+
+        <br /><br />
+
+        <ListButton id='archive'>
+          <span className='d-flex'>
+            <Archive className='px-2' />
+            <span>Color on Hover</span>
           </span>
         </ListButton>
 

--- a/src/ListButton/ListButton.tsx
+++ b/src/ListButton/ListButton.tsx
@@ -4,11 +4,13 @@ import classnames from 'classnames'
 import './index.scss'
 
 interface IListButtonProps {
-  size?: 'sm' | 'normal'
+  size?: 'sm' | 'md'
 }
 
 export const ListButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & IListButtonProps> = props => {
-  const className = classnames('co-list-button', props.className, { 'co-list-button-sm': props.size === 'sm' })
+  const className = classnames(
+    'co-list-button', props.className, `co-list-button-${props.size || 'md'}`
+  )
   return (
     <button 
       {...props} 

--- a/src/ListButton/index.scss
+++ b/src/ListButton/index.scss
@@ -1,14 +1,25 @@
 @import '../style/colors.scss';
 
-.co-list-button {
+@mixin list-button {
   background: #FFFFFF;
   border-radius: 18px;
   border: none;
-  padding: 7px 14px;
   outline: none;
   box-sizing: border-box;
   border: 1px solid white;
+  display: flex;
+  align-items: center;
+}
+
+.co-list-button {
+  @include list-button;
+}
+
+.co-list-button-md {
+  @include list-button;
+  padding: 7px 14px;
   color: $doseme-blue;
+  height: 32px;
 }
 
 .co-list-button:not([disabled]) {
@@ -21,6 +32,8 @@
 }
 
 .co-list-button-sm {
+  @include list-button;
+
   height: 24px;
   font-size: 12px;
   line-height: 14px;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './style/colors'
+export * from './ActionButton'
 export * from './AddButton'
 export * from './AdminLogo'
 export * from './BackArrowButton'


### PR DESCRIPTION
Due to high complexity (specific box shadow for each icon action button) I just made them one by one. This was very tedious. Now we have the right buttons for mobile and desktop.

Also added some styling for the delete modal on mobile.

Desktop

![image](https://user-images.githubusercontent.com/19196536/89600684-f92e8380-d8a5-11ea-9ff9-e812c1e4c179.png)

Mobile

![image](https://user-images.githubusercontent.com/19196536/89600700-021f5500-d8a6-11ea-9e04-9478924b6c97.png)

