### PR TITLE
Technical/ie compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohesive-ui",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "main": "dist/cohesive-ui.cjs.js",
   "module": "dist/cohesive-ui.esm.js",
   "files": [

--- a/src/DateTextInput/DateTextInput.tsx
+++ b/src/DateTextInput/DateTextInput.tsx
@@ -34,7 +34,10 @@ export const validate = (value: IDateState, customValidator?: (value: IDateState
 
   // do not allow invalid days, like 31st of Feb.
   if (new Date(`${yyyy}-${mm}-${dd}`).getDate() !== dd) {
-    return { valid: false, message: 'Invalid date' }
+    // IE uses yyyy/mm/dd, try that
+    if (new Date(`${yyyy}/${mm}/${dd}`).getDate() !== dd) {
+      return { valid: false, message: 'Invalid date' }
+    }
   }
 
   if (customValidator) {

--- a/src/Grid/Container.tsx
+++ b/src/Grid/Container.tsx
@@ -1,14 +1,12 @@
-import React, { HTMLProps } from 'react'
+import React from 'react'
 import classnames from 'classnames'
 
 import './index.scss'
 
-type TProps = HTMLProps<HTMLDivElement> & { fluid?: boolean }
+const Container: React.FC<React.HTMLAttributes<HTMLDivElement> & { fluid?: boolean }> = (props) => {
+  let className = classnames(props.className, 'co-container', { 'co-container-fluid': props.fluid })
 
-const Container: React.FC<TProps> = (props) => {
-  let className = classnames('co-container', { 'co-container-fluid': props.fluid })
-
-  return <div className={className}>{props.children}</div>
+  return <div {...props} className={className}>{props.children}</div>
 }
 
 export {

--- a/src/Modal/index.scss
+++ b/src/Modal/index.scss
@@ -15,10 +15,6 @@
 .regular-overlay {
   z-index: 1050;
 
-  #modal-body {
-    position: absolute;
-  }
-  
   @include mobile-only {
     #modal-body {
       width: 100%;

--- a/src/shared/input.scss
+++ b/src/shared/input.scss
@@ -10,6 +10,16 @@
   background: white;
 }
 
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .co-input-units {
+    line-height: 15px;
+  }
+
+  .co-input {
+    line-height: 9px;
+  }
+}
+
 .co-input {
   outline: none;
   border: none;


### PR DESCRIPTION
Some IE compat:

- new Date uses `/` instead of `-` in IE. Both `/` and `-` work in other browsers
- allow passing className to `<Container>`
- IE only line-height to make `<TextInput>` look correct