### PR TITLE
UI-58 add async validation to text input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohesive-ui",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "dist/cohesive-ui.cjs.js",
   "module": "dist/cohesive-ui.esm.js",
   "files": [

--- a/src/Icons/Checkmark/Checkmark.tsx
+++ b/src/Icons/Checkmark/Checkmark.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface ICheckmarkProps {
+  fill?: string
+}
+
+export const Checkmark: React.FC<ICheckmarkProps> = (props) => {
+  return (
+    <svg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path fillRule='evenodd' clipRule='evenodd' d='M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16Z' fill={props.fill || '#59B662'} />
+      <path fillRule='evenodd' clipRule='evenodd' d='M7.47749 11.3256L7.3113 11.5168L3.53846 8.23714L4.45617 7.18142L7.17644 9.54612L11.3463 4.74928L12.3995 5.66487L7.47818 11.3262L7.47749 11.3256Z' fill='white' />
+    </svg>
+  )
+}

--- a/src/Icons/Checkmark/index.ts
+++ b/src/Icons/Checkmark/index.ts
@@ -1,0 +1,1 @@
+export * from './Checkmark'

--- a/src/Icons/Cross/Cross.tsx
+++ b/src/Icons/Cross/Cross.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+interface ICrossProps {
+  fill?: string
+}
+
+export const Cross: React.FC<ICrossProps> = (props) => {
+  return (
+    <svg width='16' height='17' viewBox='0 0 16 17' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path d='M0 16.12H16V0.12H0V16.12Z' fill='url(#pattern0)' />
+      <defs>
+        <pattern id='pattern0' patternContentUnits='objectBoundingBox' width='1' height='1'>
+          <use href='#image0' transform='scale(0.015625)' />
+        </pattern>
+        <image id='image0' width='64' height='64' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAFcUlEQVR4AdWbA7BkRxSGz0Ns27a9tr3FlFKKbRvFqBAUY5uLQmzbGHvm+s7uzf+yp6pO1JPpHvQ7Vd967/T33R7P0P+Z5owZZzVnzRpPo2Sw1oOx5mvjmTPXI8UkRMPUauKJE6+It946iffa65d49uzDbZeP58zZNT7ooA+iLbdM4jFj7sXvh/UPNnnyFfFWWyUR0Z/E++33HQ5obYR47txd48MOeycaHl6z5k02SeLx4+9WRFDLj1QMiRgwMJBEHMFG+QjyIeTlmqONNxYRTOTVEeyTl7QTIYJ8CPlAHEASiAiRBREiIa9cMyJEiBBxhFbyrUGEkCP0Wz5g+ZaoIoRKeXWEsA8RQsiHCnlVhBAR8P/XREhmzBiKp069woe8T9Q+iBBwhF7L+5DXWjPvhGT27PWpcMQRF0d8V+cB2yMEJvLsGIIm7iKLRxxxD904MLBoOVFlNVESA08XRPARIUCEbsoHkPcgr7VGlk/Au0ThzQMDpxJhLiSaigj5kQgRcK2LYC7vCvn3iLwriE4kORchwjJEWCUiaNHpCCzvQ96FvO66AiF/uZSXcyEivMoRQuBYEMFInh38/5RXRGhyNUcXRPAQwTeI4EPeg7wDea01CPl3W8qLuYAjxByh0fMI5vIN4IHVreXVOyHmig1dEMFFBK+NCB7kXcg3IK91mSy/CryjIy8jvIIIEUeodz2CuXwduEL+MpbXngtEBA/UdWkVQcjXIa91GSzfBG9ryysihByhZhDB+Y8ILP+2rnwNOOby6ggvcwQX1HThCK54ec3Fy1gO5GuQ1zomy8fgLXP51hECjlA1iNDYd9/v3Pnz93UXLtzGRL4KGhry2nM+IrzEERxQNaBxyCHfNo455oMq5LWPASLwJuQvNZLXiOBzhIpuBOyE6tCQ1v+tgHpP5RURGqDSS1g+NJM3n/MQ4UVE8DhCuQfiZVBj+Tf6KS8jvMAR6qDcTVg+YPlLpLwNEVyOUOqCeAlUWf51K+QVEWqg1ElY3mf5i6W8zRGKHRAvCnlx5u2dMxHhKUTgGy0ImFHmmCshfx7LWz8XrbXW8cvWWuu3mjiLutTBe8PDxSvXWms+jZb5fNy4Hb/eeeevCyxRMKAEvt9669RnY8YcMirkg4UL9/GPOOKj2rrrsoQ5lbXWSrwDDvg5WLDgeKvla3Pm7FM++OCP84ODSZ6o45T22efX6uzZdkaoasjrULYuAsuXWD7XRfmc2AkVRLBKPsfyvaJoQ4SKgfyoj1CGfBHyWchnibTIMVkDCohQ7nWEirE836AxBZAxiFCUEWyXz7BwBbxCVHuKKMMPeDiCpTtBymcgj8W2TZrlq2AZUf0colmnEh3xBNGvZX7UmAYZTWQEy+SBkH8V8ucTLSWes4jGdDDCL5VORyh34Mzn/0P+7xFKHYogd4KxfAHyachjUe3D8hWWPw/yiqfSYx7nCAWQNiCPCCVE6Kt8CuRU8ooIRY6QMopgsBNKPTzzdu0Els+zfMrwzL+ilm+9Ezik1jqYHEdoSz7F8u3yO98vlw3kZYTHRITfNdYjIxQRoevyOYW8LREskLcsQnHu3K7JWxthzpw1Ebxp046tHHLIp92QtzkCXlT5zZ0+fSY9tsUWt3wB+RLfcnZK3t4I/EozeHyLLR6l04i2upHo/i/5bittr7x5BJb/CdxGtOwUol0IQ6cSrXeTjGAgb3MEIf8qnLciOacpIhjI2xFByN8O+dOkvDKCgbxNEaS8PPNtRFDLWxdBS14RIaV4eGttBIV82xHqCnkbIxR4zT/qyssItyDC10TJCiJPytsc4Wmi1Ij8nUTLWF7/K+RnE61/FdE9FxGdRKNkLiSacS3RQ+cQbU8t5g9mxhwsQlgwdwAAAABJRU5ErkJggg==' />
+      </defs>
+    </svg>
+  )
+}

--- a/src/Icons/Cross/index.ts
+++ b/src/Icons/Cross/index.ts
@@ -1,0 +1,1 @@
+export * from './Cross'

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -14,7 +14,7 @@ interface IInputProps extends ILabelProps {
   disabled?: boolean
   readOnly?: boolean
   icon?: JSX.Element
-  onChange?: (event: any) => any
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => any
   onBlur?: (event: React.FormEvent<HTMLInputElement>) => void
   onFocus?: () => void
   className?: string

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -13,7 +13,8 @@ interface IInputProps extends ILabelProps {
   valid: boolean
   disabled?: boolean
   readOnly?: boolean
-  onChange?: (event: React.FormEvent<HTMLInputElement>) => any
+  icon?: JSX.Element
+  onChange?: (event: any) => any
   onBlur?: (event: React.FormEvent<HTMLInputElement>) => void
   onFocus?: () => void
   className?: string
@@ -60,6 +61,7 @@ export const Input: React.FC<IInputProps> = (props) => {
         disabled={disabled}
         readOnly={readOnly}
       />
+      <span className='co-async-validation-icon'>{props.icon}</span>
       {units && <div className='co-input-units'>{units}</div>}
     </div>
   )

--- a/src/Label/Label.tsx
+++ b/src/Label/Label.tsx
@@ -3,6 +3,8 @@ import './index.scss'
 
 export interface IProps {
   error?: string
+  info?: string
+  success?: string
 }
 
 export interface ILabelProps {
@@ -17,7 +19,9 @@ const Label: React.FC<IProps & ILabelProps> = (props) => {
         {props.label}
         {props.showOptional && <span className='co-form-field-optional-label'>(Optional)</span>}
       </div>
-      <small className='validation-error-text ml-auto'>{props.error}</small>
+      <small className='co-label-text validation-error-text ml-auto'>{props.error}</small>
+      {props.info && <small className='co-label-text ml-auto co-async-input-loading'>{props.info}</small>}
+      {props.success && <small className='co-label-text ml-auto co-async-input-success'>{props.success}</small>}
     </div>
   )
 }

--- a/src/Label/index.scss
+++ b/src/Label/index.scss
@@ -1,9 +1,12 @@
 @import '../style/colors.scss';
 
-.validation-error-text {
-  color: $invalidRed;
+.co-label-text {
   text-transform: uppercase;
   font-size: 10px;
+}
+
+.validation-error-text {
+  color: $invalidRed;
 }
 
 .co-form-field-label {
@@ -17,4 +20,12 @@
   color: $darkgrey;
   font-weight: bold;
   margin: 0 0 0 5px;
+}
+
+.co-async-input-loading {
+  color: $panelblue;
+}
+
+.co-async-input-success {
+  color: $validgreen;
 }

--- a/src/TextInput/TextInput.spec.tsx
+++ b/src/TextInput/TextInput.spec.tsx
@@ -48,6 +48,7 @@ describe('TextInput', () => {
     const wrapper = render(
       <TextInput
         label='Async validation'
+        info='checking existing'
         name='my-input'
         onChange={noop}
         onBlur={noop}
@@ -60,7 +61,7 @@ describe('TextInput', () => {
       fireEvent.blur(screen.getByTestId('my-input'))
     })
 
-    expect(await wrapper.findByText(/checking system/)).toBeTruthy()
+    expect(await wrapper.findByText(/checking existing/)).toBeTruthy()
     expect(await wrapper.findByText(/All good/)).toBeTruthy()
 
     valid = false
@@ -70,7 +71,7 @@ describe('TextInput', () => {
       fireEvent.blur(screen.getByTestId('my-input'))
     })
 
-    expect(await wrapper.findByText(/checking system/)).toBeTruthy()
+    expect(await wrapper.findByText(/checking existing/)).toBeTruthy()
     expect(await wrapper.findByText(/No good/)).toBeTruthy()
   })
 })

--- a/src/TextInput/TextInput.spec.tsx
+++ b/src/TextInput/TextInput.spec.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 
-import { TextInput } from './TextInput'
+import { TextInput, IAsyncValidationResult } from './TextInput'
+
+const noop = jest.fn()
 
 describe('TextInput', () => {
   it('works', async () => {
-    const noop = jest.fn()
-    const { debug } = render(
+    const wrapper = render(
       <TextInput 
         label='This has a default value'
         name='my-input'
@@ -21,15 +22,55 @@ describe('TextInput', () => {
     )
 
     // type some text and blur - input is valid
-    fireEvent.change(screen.getByTestId('my-input'), { target: { value: 'value' } })
-    fireEvent.blur(screen.getByTestId('my-input'))
-    expect(screen.queryByTestId(/Required/)).toBeNull()
+    act(() => {
+      fireEvent.change(screen.getByTestId('my-input'), { target: { value: 'value' } })
+      fireEvent.blur(screen.getByTestId('my-input'))
+    })
+    expect(wrapper.queryByText(/Required/)).toBeNull()
 
     // set to empty string and blur - now the input is invalid
-    fireEvent.change(screen.getByTestId('my-input'), { target: { value: '' } })
-    fireEvent.blur(screen.getByTestId('my-input'))
+    act(() => {
+      fireEvent.change(wrapper.getByTestId('my-input'), { target: { value: '' } })
+      fireEvent.blur(wrapper.getByTestId('my-input'))
+    })
 
-    expect(screen.queryByText(/Required/)).toBeInTheDocument()
-    screen.getByText('mg')
+    expect(await wrapper.findByText(/Required/)).toBeInTheDocument()
+    wrapper.getByText('mg')
+  })
+
+  it('validates asynchronously', async () => {
+    let valid = true
+    let message = 'All good'
+    const asyncValidator = async (): Promise<IAsyncValidationResult> => {
+      return new Promise(res => res({ valid, message }))
+    }
+
+    const wrapper = render(
+      <TextInput
+        label='Async validation'
+        name='my-input'
+        onChange={noop}
+        onBlur={noop}
+        asyncValidator={asyncValidator}
+      />
+    )
+
+    act(() => {
+      fireEvent.change(screen.getByTestId('my-input'), { target: { value: 'value' } })
+      fireEvent.blur(screen.getByTestId('my-input'))
+    })
+
+    expect(await wrapper.findByText(/checking system/)).toBeTruthy()
+    expect(await wrapper.findByText(/All good/)).toBeTruthy()
+
+    valid = false
+    message = 'No good'
+    act(() => {
+      fireEvent.change(screen.getByTestId('my-input'), { target: { value: 'value' } })
+      fireEvent.blur(screen.getByTestId('my-input'))
+    })
+
+    expect(await wrapper.findByText(/checking system/)).toBeTruthy()
+    expect(await wrapper.findByText(/No good/)).toBeTruthy()
   })
 })

--- a/src/TextInput/TextInput.stories.tsx
+++ b/src/TextInput/TextInput.stories.tsx
@@ -1,9 +1,38 @@
-import React from 'react'
+import React, { useState } from 'react'
 import noop from 'lodash/noop'
 import { storiesOf } from '@storybook/react'
 
-import { TextInput } from './TextInput'
+import { TextInput, IAsyncValidationResult } from './TextInput'
 
+const AsyncValidationStory = () => {
+  const [returnValid, setReturnValid] = useState(false)
+
+  const asyncValidator = async (): Promise<IAsyncValidationResult> => {
+    return new Promise(res => {
+      setTimeout(() => res({ 
+        valid: returnValid, 
+        message: returnValid ? 'available' : 'already exists'
+      }), 500)
+    })
+  }
+
+  return (
+    <div className='m-4'>
+      <h3 className='co-h3'>Async Validation</h3>
+      <div className='my-2'>
+        <input id='valid' type='checkbox' checked={returnValid} onChange={() => setReturnValid(!returnValid)} />
+        <label htmlFor='valid'>Return valid response?</label>
+      </div>
+
+      <TextInput
+        label='Async validation'
+        onChange={noop}
+        onBlur={noop}
+        asyncValidator={asyncValidator}
+      />
+    </div>
+  )
+}
 
 storiesOf('Components.Form.TextInput', module)
   .add('Required input, 20 max length', () => {
@@ -67,6 +96,8 @@ storiesOf('Components.Form.TextInput', module)
             units='mg'
           />
         </div>
+
+        <AsyncValidationStory />
       </>
     )
   })

--- a/src/TextInput/TextInput.stories.tsx
+++ b/src/TextInput/TextInput.stories.tsx
@@ -27,6 +27,7 @@ const AsyncValidationStory = () => {
       <TextInput
         label='Async validation'
         onChange={noop}
+        info='checking'
         onBlur={noop}
         asyncValidator={asyncValidator}
       />

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -3,7 +3,16 @@ import React, { useState } from 'react'
 import { validate } from './validation'
 import { Input } from '../Input/Input'
 import { Label, ILabelProps } from '../Label'
+import { Spinner } from '../Spinner'
 import '../shared/input.scss'
+import { PANELBLUE } from '../style/colors'
+import { Checkmark } from '../Icons/Checkmark'
+import { Cross } from '../Icons/Cross'
+
+export interface IAsyncValidationResult {
+  valid: boolean
+  message: string
+}
 
 interface IProps {
   placeholder?: string
@@ -14,11 +23,12 @@ interface IProps {
   disabled?: boolean
   isRequired?: boolean
   readOnly?: boolean
+  className?: string
+  units?: string
+  asyncValidator?: (value: string) => Promise<IAsyncValidationResult>
   onChange?: (value: string) => void
   onBlur?: (value: string, isValid: boolean) => void
   onFocus?: () => void
-  className?: string
-  units?: string
 }
 
 const TextInput: React.FC<IProps & ILabelProps> = (props) => {
@@ -36,13 +46,17 @@ const TextInput: React.FC<IProps & ILabelProps> = (props) => {
     type,
     defaultValue,
     units,
+    asyncValidator,
     ...rest
   } = props
 
   const [error, setError] = useState<string>('')
-  const [isValid, setValid] = useState<boolean>(true)
+  const [loading, setLoading] = useState(false)
+  const [validityIcon, setValidityIcon] = useState<JSX.Element | undefined>()
+  const [success, setSuccess] = useState('')
+  const [isValid, setValid] = useState(true)
 
-  const onValidate = (str: string): boolean => {
+  const onValidate = async (str: string): Promise<boolean> => {
     const status = validate({
       maxInputLength,
       isRequired,
@@ -53,34 +67,61 @@ const TextInput: React.FC<IProps & ILabelProps> = (props) => {
       return false
     }
 
+    if (props.asyncValidator) {
+      setLoading(true)
+      setError('')
+      setValidityIcon(<Spinner size='1x' color={PANELBLUE} />)
+
+      // it is possible in input value is valid on the client side but async validation could fail.
+      // eg: duplicate longid/mrn.
+      const asyncResult = await props.asyncValidator(str)
+      setLoading(false)
+
+      if (!asyncResult.valid) {
+        setError(asyncResult.message)
+        setValidityIcon(<Cross />)
+        setSuccess('')
+        return false
+      } else {
+        setSuccess(asyncResult.message)
+        setValidityIcon(<Checkmark />)
+      }
+    }
+
     setError('')
     return true
   }
 
   const fieldClass = isValid ? 'ui-form co-input' : 'ui-form form-field-invalid co-input'
 
-  const update = (e: React.FormEvent<HTMLInputElement>): void => {
-    const valid = onValidate(e.currentTarget.value)
+  const update = async (e: React.FormEvent<HTMLInputElement>): Promise<void> => {
+    const value = e.currentTarget.value
+    const valid = await onValidate(value)
     setValid(valid)
+
     if (onBlur) {
-      onBlur(e.currentTarget.value, valid)
+      onBlur(value, valid)
     }
   }
 
   const clearAndHandleChange = (value: string) => {
     setError('')
+    setSuccess('')
+    setValidityIcon(undefined)
     setValid(true)
 
     if (onChange) {
       onChange(value)
     }
   }
-
+  
   return (
     <div className={props.className}>
       <Label 
         label={label}
         error={error}
+        info={loading ? 'checking system...' : undefined}
+        success={success}
         showOptional={props.showOptional}
       />
       <Input 
@@ -93,6 +134,7 @@ const TextInput: React.FC<IProps & ILabelProps> = (props) => {
         valid={isValid}
         onBlur={update}
         onChange={(e) => clearAndHandleChange(e.currentTarget.value)}
+        icon={validityIcon}
         onFocus={onFocus}
         disabled={disabled}
         readOnly={readOnly}

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -25,6 +25,7 @@ interface IProps {
   readOnly?: boolean
   className?: string
   units?: string
+  info?: string
   asyncValidator?: (value: string) => Promise<IAsyncValidationResult>
   onChange?: (value: string) => void
   onBlur?: (value: string, isValid: boolean) => void
@@ -120,7 +121,7 @@ const TextInput: React.FC<IProps & ILabelProps> = (props) => {
       <Label 
         label={label}
         error={error}
-        info={loading ? 'checking system...' : undefined}
+        info={loading ? props.info : undefined}
         success={success}
         showOptional={props.showOptional}
       />

--- a/src/shared/input.scss
+++ b/src/shared/input.scss
@@ -3,6 +3,7 @@
 .co-input-wrapper {
   display: flex;
   align-items: center;
+  position: relative;
 }
 
 .co-input, .co-input-units {
@@ -65,4 +66,10 @@
     box-shadow: none;
     border-color: $panelblue;
   }
+}
+
+.co-async-validation-icon {
+  position: absolute;
+  top: 12px;
+  right: 10px;
 }

--- a/src/style/colors.scss
+++ b/src/style/colors.scss
@@ -13,7 +13,7 @@ $footerblack: rgb(32, 32, 32);
 $footerlink: rgb(2, 169, 220);
 $footerhover: rgb(52, 152, 219);
 $bgwhite: rgb(246, 247, 251); 
-$validGreen: rgb(40, 167, 69);
+$validgreen: rgb(40, 167, 69);
 $invalidRed: rgb(220, 53, 69);
 $shadow: rgba(180, 180, 180, 0.3);
 $navy: rgb(14, 78, 149);


### PR DESCRIPTION
Add async validation to the text input control.

It would have been nice to have this work other controls (Number, Date) but the way we set things up made this not realistic. Hopefully we won't need any other async controls, anyway.

Usage is something like this:

```js
  const validateLongid = async (value: string): Promise<IAsyncValidationResult> => {
    const result = await axios.get<IAsyncValidationResult>(`/api/v2/patients/validate_longid/${value}`)
    return result.data
  }

  const patientIdInput: JSX.Element = (
    <TextInput
      label='Patient ID'
      name='longid'
      asyncValidator={validateLongid}
      isRequired
      onChange={value => updateInput('longid', value)}
      onBlur={(value, valid) => updateValid('longid', valid)}
    />
  )

```

![gif](https://user-images.githubusercontent.com/19196536/92348623-f6c68000-f116-11ea-9116-24cf155daf4c.gif)
